### PR TITLE
Support dynamic subexpressions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,26 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    uses: actions/checkout@v2
+    with:
+      submodules: recursive
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/eval.go
+++ b/eval.go
@@ -867,7 +867,12 @@ func (v *evalVisitor) VisitPartial(node *ast.PartialStatement) interface{} {
 	name, ok := ast.HelperNameStr(node.Name)
 	if !ok {
 		if subExpr, ok := node.Name.(*ast.SubExpression); ok {
-			name, _ = subExpr.Accept(v).(string)
+			switch subExprResult := subExpr.Accept(v).(type) {
+			case string:
+				name = subExprResult
+			case SafeString:
+				name = string(subExprResult)
+			}
 		}
 	}
 

--- a/eval.go
+++ b/eval.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aymerick/raymond/ast"
+	"github.com/mancusi/raymond/ast"
 )
 
 var (

--- a/eval_test.go
+++ b/eval_test.go
@@ -72,6 +72,19 @@ var evalTests = []Test{
 		nil, nil, nil,
 		"C",
 	},
+	{
+		name:     "dynamic partial from subexpression",
+		input:    `{{> (whichPartial)}}`,
+		data:     map[string]string{"slug": "slug"},
+		privData: map[string]interface{}{},
+		helpers: map[string]interface{}{
+			"whichPartial": func() string { return "dynamicPartial" },
+		},
+		partials: map[string]string{
+			"dynamicPartial": `<div>dynamic</div>`,
+		},
+		output: `<div>dynamic</div>`,
+	},
 
 	// @todo Test with a "../../path" (depth 2 path) while context is only depth 1
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/mancusi/raymond
+
+go 1.16
+
+require gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/handlebars/base_test.go
+++ b/handlebars/base_test.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/aymerick/raymond"
+	"github.com/mancusi/raymond"
 )
 
 // cf. https://github.com/aymerick/go-fuzz-tests/raymond

--- a/handlebars/basic_test.go
+++ b/handlebars/basic_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aymerick/raymond"
+	"github.com/mancusi/raymond"
 )
 
 //

--- a/handlebars/data_test.go
+++ b/handlebars/data_test.go
@@ -3,7 +3,7 @@ package handlebars
 import (
 	"testing"
 
-	"github.com/aymerick/raymond"
+	"github.com/mancusi/raymond"
 )
 
 //

--- a/handlebars/helpers_test.go
+++ b/handlebars/helpers_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aymerick/raymond"
+	"github.com/mancusi/raymond"
 )
 
 //

--- a/handlebars/subexpressions_test.go
+++ b/handlebars/subexpressions_test.go
@@ -3,7 +3,7 @@ package handlebars
 import (
 	"testing"
 
-	"github.com/aymerick/raymond"
+	"github.com/mancusi/raymond"
 )
 
 //

--- a/helper.go
+++ b/helper.go
@@ -388,7 +388,7 @@ func lookupHelper(obj interface{}, field string, options *Options) interface{} {
 }
 
 // #equal helper
-// Ref: https://github.com/aymerick/raymond/issues/7
+// Ref: https://github.com/mancusi/raymond/issues/7
 func equalHelper(a interface{}, b interface{}, options *Options) interface{} {
 	if Str(a) == Str(b) {
 		return options.Fn()

--- a/helper_test.go
+++ b/helper_test.go
@@ -245,7 +245,7 @@ func TestRemoveHelper(t *testing.T) {
 }
 
 //
-// Fixes: https://github.com/aymerick/raymond/issues/2
+// Fixes: https://github.com/mancusi/raymond/issues/2
 //
 
 type Author struct {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"strconv"
 
-	"github.com/aymerick/raymond/ast"
-	"github.com/aymerick/raymond/lexer"
+	"github.com/mancusi/raymond/ast"
+	"github.com/mancusi/raymond/lexer"
 )
 
 // References:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aymerick/raymond/ast"
-	"github.com/aymerick/raymond/lexer"
+	"github.com/mancusi/raymond/ast"
+	"github.com/mancusi/raymond/lexer"
 )
 
 type parserTest struct {

--- a/parser/whitespace.go
+++ b/parser/whitespace.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"regexp"
 
-	"github.com/aymerick/raymond/ast"
+	"github.com/mancusi/raymond/ast"
 )
 
 // whitespaceVisitor walks through the AST to perform whitespace control

--- a/template.go
+++ b/template.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/aymerick/raymond/ast"
-	"github.com/aymerick/raymond/parser"
+	"github.com/mancusi/raymond/ast"
+	"github.com/mancusi/raymond/parser"
 )
 
 // Template represents a handlebars template.


### PR DESCRIPTION
Migrates the newly forked library to use go modules and fixes a bug preventing dynamic partials from working properly.